### PR TITLE
Bug fix: tensors are not on the same device when

### DIFF
--- a/df2d/inference.py
+++ b/df2d/inference.py
@@ -121,7 +121,7 @@ def inference(
     for batch in tqdm(dataset):
         x, _, d = batch
         hm = model(x)
-        points, conf = heatmap2points(hm)
+        points, conf = heatmap2points(hm.cpu())
         points = points.cpu().data.numpy()
         conf = conf.cpu().data.numpy()
         if return_heatmap:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="nely-df2d",
-    version="0.13",
+    version="0.14",
     packages=["df2d"],
     author="Semih Gunel",
     author_email="gunelsemih@gmail.com",


### PR DESCRIPTION


When converting probability heatmap to coordinates, the input (heatmap) might still be on the GPU. This can cause problem when writing the coordinates to CPU tensors.
