### PR TITLE
Significantly speed up the model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+weights/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/df2d/inference.py
+++ b/df2d/inference.py
@@ -51,7 +51,7 @@ def inference_folder(
     inp = path2inp(
         folder, max_img_id=max_img_id
     )  # extract list of images under the folder
-    dat = DataLoader(Drosophila2Dataset(inp, load_f=load_f), batch_size=8)
+    dat = DataLoader(Drosophila2Dataset(inp, load_f=load_f), batch_size=8, num_workers=16, pin_memory=True)
 
     return inference(
         model, dat, return_heatmap=return_heatmap, return_confidence=return_confidence
@@ -108,7 +108,7 @@ def path2inp(path: str, max_img_id: Optional[int] = None) -> List[str]:
 
     return img_list
 
-
+@torch.inference_mode()
 def inference(
     model: Drosophila2DPose,
     dataset: Drosophila2Dataset,
@@ -118,6 +118,7 @@ def inference(
     res = list()
     res_conf = list()
     heatmap = list()
+
     for batch in tqdm(dataset):
         x, _, d = batch
         hm = model(x)

--- a/df2d/model.py
+++ b/df2d/model.py
@@ -36,7 +36,7 @@ class Drosophila2DPose(pl.LightningModule):
         if checkpoint_path is not None:
             pretrained = {
                 k.replace("module.", ""): v
-                for (k, v) in torch.load(checkpoint_path, map_location=device)[
+                for (k, v) in torch.load(checkpoint_path, map_location=device, weights_only=True)[
                     "state_dict"
                 ].items()
             }

--- a/df2d/util.py
+++ b/df2d/util.py
@@ -2,7 +2,9 @@ import os
 from itertools import product
 
 import numpy as np
+import torch
 from torch.functional import Tensor
+from torchvision import utils
 
 
 def pwd():
@@ -48,11 +50,6 @@ def draw_labelmap(img: np.ndarray, pt, sigma=3, type="Gaussian"):
 
     img[img_y[0] : img_y[1], img_x[0] : img_x[1]] = g[g_y[0] : g_y[1], g_x[0] : g_x[1]]
     return img
-
-
-import torch
-from torch.functional import Tensor
-from torchvision import utils
 
 
 def tensorboard_plot_image(

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "pytorch_lightning",
         "scikit-image",
         "torch",
+        "torchvision",
         "tqdm",
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,12 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/NeLy-EPFL/Drosophila2DPose",
+    install_requires = [
+        "matplotlib",
+        "numpy",
+        "pytorch_lightning",
+        "scikit-image",
+        "torch",
+        "tqdm",
+    ]
 )


### PR DESCRIPTION
Fixes #3

After some testing, I found that the model inference was being slowed down by the data loading from CPU to GPU more than anything else, so the GPU wasn't able to be fully utilised.

I tested the ideas mentioned [here](https://pytorch.org/serve/performance_checklist.html) and [here](https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html).
* using `torch.inference_mode()` helped a tiny bit
* using `num_workers > 0` in the `DataLoader` helped **a lot**. I got the following results for time to run using the H100 GPU
  * 0 workers (default) - 1:18:00
  * 8 workers - 0:15:00
  * 16 workers - 0:08:00
  * 32 workers - 0:08:00
* using `pin_memory=True` helped a bit too
  * with 16 workers we get 0:05:00

In total the model inference is now about 10-15 times faster. We can process ~300 fps on the L40s GPU instead of ~30 before.

From what I can tell, being bottlenecked by the dataloaders is usually caused by needing preprocessing of the images before they get sent to the GPU and having this slow things down. Maybe we could use torch transforms in `Drosophila2Dataset` to speed things up a bit?